### PR TITLE
Add target task to prod-build

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -18,7 +18,8 @@
   (comp (cljs :ids #{"main"}
               :optimizations :simple)
         (cljs :ids #{"renderer"}
-              :optimizations :advanced)))
+              :optimizations :advanced)
+        (target)))
 
 (deftask dev-build []
   (comp ;; Audio feedback about warnings etc. =======================


### PR DESCRIPTION
Add a `(target)` task to `prod-build` so that changes get written to disk.